### PR TITLE
fix params doesnt accept false

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.validate_lab.confluence</groupId>
     <artifactId>stoplightelements_previewer</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
 
     <organization>
         <name>ValidateLab</name>

--- a/src/main/java/com/validate_lab/confluence/stoplightelements_previewer/macro/StoplightElementsPreviewer.java
+++ b/src/main/java/com/validate_lab/confluence/stoplightelements_previewer/macro/StoplightElementsPreviewer.java
@@ -26,11 +26,11 @@ public class StoplightElementsPreviewer implements Macro {
 
         return "<elements-api" +
                 " apiDescriptionUrl=\"" + parameters.get("link") + "\"" +
-                " hideInternal=\"" + getBoolean(parameters, "hideInternal", "false") + "\"" +
-                " hideTryIt=\"" + getBoolean(parameters, "hideTryIt", "false") + "\"" +
-                " hideTryItPanel=\"" + getBoolean(parameters, "hideTryItPanel", "false") + "\"" +
-                " hideSchemas=\"" + getBoolean(parameters, "hideSchemas", "false") + "\"" +
-                " hideExport=\"" + getBoolean(parameters, "hideExport", "false") + "\"" +
+                getBoolean(parameters, "hideInternal") +
+                getBoolean(parameters, "hideTryIt") +
+                getBoolean(parameters, "hideTryItPanel") +
+                getBoolean(parameters, "hideSchemas") +
+                getBoolean(parameters, "hideExport") +
                 " router=\"hash\"" +
                 " />";
     }
@@ -43,12 +43,13 @@ public class StoplightElementsPreviewer implements Macro {
         return OutputType.BLOCK;
     }
 
-    private String getBoolean(Map<String, String> parameters, String parameter, String defaultValue) {
+    private String getBoolean(Map<String, String> parameters, String parameter) {
         String value = parameters.get(parameter);
-        if (value == null) {
-            return defaultValue;
+        // Params doesn't accept false values (converted "false" to true)
+        if (value == null || value.equals("false")) {
+            return "";
         }
 
-        return value;
+        return " " + parameter + "=\"true\"";
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Boolean macro options (e.g., hideInternal, hideTryIt, hideTryItPanel, hideSchemas, hideExport) now default to off and only activate when explicitly enabled. Providing any non-"false" value turns the option on; omitting or setting "false" keeps it off, resulting in cleaner, more predictable previews.

* **Chores**
  * Bumped version to 1.3.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->